### PR TITLE
Include thrown exception in onError() callback

### DIFF
--- a/app/src/main/java/com/prof/rssparser/example/MainActivity.java
+++ b/app/src/main/java/com/prof/rssparser/example/MainActivity.java
@@ -129,7 +129,7 @@ public class MainActivity extends AppCompatActivity {
 
             //what to do in case of error
             @Override
-            public void onError() {
+            public void onError(Exception exception) {
 
                 runOnUiThread(new Runnable() {
                     @Override

--- a/rssparser/src/main/java/com/prof/rssparser/Parser.java
+++ b/rssparser/src/main/java/com/prof/rssparser/Parser.java
@@ -47,7 +47,7 @@ public class Parser extends AsyncTask<String, Void, String> implements Observer 
     public interface OnTaskCompleted {
         void onTaskCompleted(ArrayList<Article> list);
 
-        void onError();
+        void onError(Exception exception);
     }
 
     public void onFinish(OnTaskCompleted onComplete) {
@@ -69,7 +69,7 @@ public class Parser extends AsyncTask<String, Void, String> implements Observer 
                 return response.body().string();
         } catch (IOException e) {
             e.printStackTrace();
-            onComplete.onError();
+            onComplete.onError(e);
         }
         return null;
     }
@@ -83,10 +83,10 @@ public class Parser extends AsyncTask<String, Void, String> implements Observer 
                 Log.i("RSS Parser ", "RSS parsed correctly!");
             } catch (Exception e) {
                 e.printStackTrace();
-                onComplete.onError();
+                onComplete.onError(e);
             }
         } else
-            onComplete.onError();
+            onComplete.onError(new Exception("RSS parse operation returned null"));
     }
 
     @Override


### PR DESCRIPTION
Until now, it was not possible to know the reason of an error during RSS parsing because exceptions where ignored. Now, the onError() method includes the exception that was thrown so that the developer can investigate further.
Note that this is a breaking change, although it shouldn't be difficult to adapt.

I haven't included any deprecation warning because I don't know how you want to handle this. I personally think that it's a nice addition (in fact, I'm doing this pull request because it's useful for my project). I also chose the "develop" branch because I guess this is the one you actively use for day-to-day development.