### PR TITLE
Parsing image url from enclosure tag

### DIFF
--- a/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
@@ -80,6 +80,14 @@ object CoreXMLParser {
                         currentArticle.image = xmlPullParser.getAttributeValue(null, RSSKeywords.RSS_ITEM_URL)
                     }
 
+                } else if (xmlPullParser.name.equals(RSSKeywords.RSS_ITEM_ENCLOSURE, ignoreCase = true)) {
+                    if (insideItem) {
+                        val type = xmlPullParser.getAttributeValue(null, RSSKeywords.RSS_ITEM_TYPE)
+                        if (type != null && type.contains("image/")) {
+                            currentArticle.image = xmlPullParser.getAttributeValue(null, RSSKeywords.RSS_ITEM_URL)
+                        }
+                    }
+
                 } else if (xmlPullParser.name.equals(RSSKeywords.RSS_ITEM_DESCRIPTION, ignoreCase = true)) {
                     if (insideItem) {
                         val description = xmlPullParser.nextText()

--- a/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
@@ -24,8 +24,6 @@ import org.xmlpull.v1.XmlPullParserException
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.IOException
 import java.io.StringReader
-import java.text.SimpleDateFormat
-import java.util.*
 import java.util.regex.Pattern
 
 object CoreXMLParser {

--- a/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
@@ -25,10 +25,12 @@ object RSSKeywords {
     const val RSS_ITEM_AUTHOR = "dc:creator"
     const val RSS_ITEM_CATEGORY = "category"
     const val RSS_ITEM_THUMBNAIL = "media:thumbnail"
+    const val RSS_ITEM_ENCLOSURE = "enclosure"
     const val RSS_ITEM_DESCRIPTION = "description"
     const val RSS_ITEM_CONTENT = "content:encoded"
     const val RSS_ITEM_PUB_DATE = "pubDate"
     const val RSS_ITEM_URL = "url"
+    const val RSS_ITEM_TYPE = "type"
 
 
 }


### PR DESCRIPTION
This PR addresses issue [#18](https://github.com/prof18/RSS-Parser/issues/18)

Here is a [sample url](https://www.mundodeportivo.com/feed/rss/futbol/fc-barcelona) for RSS feed 