### PR TITLE
Issue 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Versions 1.4 and 1.4.1 have been deleted due to a critical dependency error. Ple
 
 ## About
 
-This is an Android library to parse a RSS Feed. You can retrive the following information about an article:
+This is an Android library to parse a RSS Feed. You can retrieve the following information about channel:
+<ul>
+<li> Title
+<li> Description
+<li> Link
+<li> Articles
+</ul>
+
+Articles can have following attributes:
 <ul>
 <li> Title
 <li> Author
@@ -23,15 +31,8 @@ This is an Android library to parse a RSS Feed. You can retrive the following in
 **Disclaimer**: This library has been built starting from RSS feed generated from a Wordpress Site. Of course it's compatible with RSS feed generated from other tipe of sites; [Here](https://www.androidauthority.com/feed/) you can find an example of RSS feed.
 
 ## How to
-#### Add the JitPack repository to your build file:
-```Gradle
-allprojects {
-    repositories {
-        maven { url 'https://jitpack.io' }
-    }
- }
- ```
- #### Add the dependency:
+#### Import:
+The library is uploaded in jCenter, so you can easily add the dependency:
 ```Gradle
 dependencies {
   compile 'com.prof.rssparser:rssparser:2.0.4'
@@ -53,8 +54,8 @@ private val url = "https://www.androidauthority.com/feed"
 coroutineScope.launch(Dispatchers.Main) {
     try {
         val parser = Parser()
-        val articleList = parser.getArticles(url)
-        // The list contains all article's data. For example you can use it for your adapter.
+        val articleList = parser.getChannel(url)
+        // Show the channel data
     } catch (e: Exception) {
         // Handle the exception
     }
@@ -74,8 +75,8 @@ parser.onFinish(new OnTaskCompleted() {
 
     //what to do when the parsing is done
     @Override
-    public void onTaskCompleted(List<Article> list) {
-        // The list contains all article's data. For example you can use it for your adapter.
+    public void onTaskCompleted(Channel channel) {
+        // Use the channel info
     }
 
     //what to do in case of error
@@ -101,9 +102,8 @@ Parser parser = new Parser();
 parser.onFinish(new Parser.OnTaskCompleted() {
     
     @Override
-    public void onTaskCompleted(ArrayList<Article> list) {
+    public void onTaskCompleted(Channel channel) {
       //what to do when the parsing is done
-      //the Array List contains all article's data. For example you can use it for your adapter. 
     }
 
     @Override

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RSS Parser
-[![Release](https://jitpack.io/v/marin-marsic/RSS-Parser.svg)](https://jitpack.io/#marin-marsic/RSS-Parser)
+[![Download](https://api.bintray.com/packages/prof18/maven/RSS-Parser/images/download.svg)](https://bintray.com/prof18/maven/YoutubeParser/_latestVersion)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![API](https://img.shields.io/badge/API-15%2B-brightgreen.svg?style=flat)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RSS Parser
+[![Release](https://jitpack.io/v/marin-marsic/RSS-Parser.svg)](https://jitpack.io/#marin-marsic/RSS-Parser)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![API](https://img.shields.io/badge/API-15%2B-brightgreen.svg?style=flat)
 
@@ -123,6 +124,7 @@ You can also download the <a href="https://github.com/prof18/RSS-Parser/blob/mas
 Please use the issues tracker only to report issues. If you have any kind of question you can ask it on [the blog post that I wrote](https://medium.com/@marcogomiero/how-to-easily-handle-rss-feeds-on-android-with-rss-parser-8acc98e8926f)
 
 ## Changelog
+- 17 May 2019 - Now parsing image url from enclosure tag - Version 2.0.4
 - 24 January 2019 - Now the date of an article is saved as String, to extend the compatibility with different formats - Version 2.0.3
 - 11 January 2019 - Moved the Java parsing on a background thread - Version 2.0.2
 - 2 January 2019 - Fixed an error on Date parsing - Version 2.0.1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ allprojects {
     }
  }
  ```
- #### Add the JitPack repository to your build file:
+ #### Add the dependency:
 ```Gradle
 dependencies {
     compile 'com.github.marin-marsic:RSS-Parser:2.0.4'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # RSS Parser
-[![Download](https://api.bintray.com/packages/prof18/maven/RSS-Parser/images/download.svg)](https://bintray.com/prof18/maven/YoutubeParser/_latestVersion)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![API](https://img.shields.io/badge/API-15%2B-brightgreen.svg?style=flat)
 
@@ -23,11 +22,18 @@ This is an Android library to parse a RSS Feed. You can retrive the following in
 **Disclaimer**: This library has been built starting from RSS feed generated from a Wordpress Site. Of course it's compatible with RSS feed generated from other tipe of sites; [Here](https://www.androidauthority.com/feed/) you can find an example of RSS feed.
 
 ## How to
-#### Import:
-The library is uploaded in jCenter, so you can easily add the dependency:
+#### Add the JitPack repository to your build file:
+```Gradle
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
+ }
+ ```
+ #### Add the JitPack repository to your build file:
 ```Gradle
 dependencies {
-  compile 'com.prof.rssparser:rssparser:2.0.3'
+    compile 'com.github.marin-marsic:RSS-Parser:2.0.4'
 }
 ```
 #### Use:

--- a/rssparser/src/main/java/com/prof/rssparser/Channel.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/Channel.kt
@@ -1,0 +1,8 @@
+package com.prof.rssparser
+
+data class Channel(
+        val title: String? = null,
+        val link: String? = null,
+        val description: String? = null,
+        val articles: MutableList<Article> = mutableListOf()
+)

--- a/rssparser/src/main/java/com/prof/rssparser/OnTaskCompleted.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/OnTaskCompleted.kt
@@ -18,6 +18,6 @@
 package com.prof.rssparser
 
 interface OnTaskCompleted {
-    fun onTaskCompleted(list: MutableList<Article>)
+    fun onTaskCompleted(channel: Channel)
     fun onError(e: Exception)
 }

--- a/rssparser/src/main/java/com/prof/rssparser/Parser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/Parser.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import kotlin.Exception
 
 class Parser(private val okHttpClient: OkHttpClient? = null) {
 
@@ -57,7 +56,7 @@ class Parser(private val okHttpClient: OkHttpClient? = null) {
      *  Cancel the execution of the fetching and the parsing.
      *
      *  N.B. this method works only if the parsing is performed with [execute], i.e. with the Java
-     *  implementation. If the parsing is performed with [getArticles], i.e. with the Kotlin
+     *  implementation. If the parsing is performed with [getChannel], i.e. with the Kotlin
      *  implementation, you have to stop the parsing using your coroutines Job.
      *  For example, [https://github.com/prof18/RSS-Parser/blob/753d297aa6b792c8da7e472d315cdec54f56abb6/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt#L61]
      *
@@ -73,7 +72,7 @@ class Parser(private val okHttpClient: OkHttpClient? = null) {
     }
 
     @Throws(Exception::class)
-    suspend fun getArticles(url: String) =
+    suspend fun getChannel(url: String) =
             withContext(Dispatchers.IO) {
                 val xml = async { CoroutineEngine.fetchXML(url, okHttpClient) }
                 return@withContext CoroutineEngine.parseXML(xml)

--- a/rssparser/src/main/java/com/prof/rssparser/engine/XMLParser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/engine/XMLParser.kt
@@ -17,15 +17,14 @@
 
 package com.prof.rssparser.engine
 
-import com.prof.rssparser.Article
+import com.prof.rssparser.Channel
 import com.prof.rssparser.core.CoreXMLParser
-import java.lang.Exception
 import java.util.concurrent.Callable
 
-class XMLParser(var xml: String) : Callable<MutableList<Article>> {
+class XMLParser(var xml: String) : Callable<Channel> {
 
     @Throws(Exception::class)
-    override fun call(): MutableList<Article> {
+    override fun call(): Channel {
         return CoreXMLParser.parseXML(xml)
     }
 }

--- a/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
@@ -19,6 +19,10 @@ package com.prof.rssparser.utils
 
 object RSSKeywords {
 
+    // channel
+    const val RSS_CHANNEL = "channel"
+
+    // article
     const val RSS_ITEM = "item"
     const val RSS_ITEM_TITLE = "title"
     const val RSS_ITEM_LINK = "link"

--- a/samplejava/src/main/java/com/prof/rssparser/sample/java/MainActivity.java
+++ b/samplejava/src/main/java/com/prof/rssparser/sample/java/MainActivity.java
@@ -31,11 +31,6 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import com.google.android.material.snackbar.Snackbar;
-import com.prof.rssparser.Article;
-
-import java.util.List;
-
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -45,6 +40,9 @@ import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import com.google.android.material.snackbar.Snackbar;
+import com.prof.rssparser.Channel;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -73,11 +71,14 @@ public class MainActivity extends AppCompatActivity {
 
         relativeLayout = findViewById(R.id.root_layout);
 
-        viewModel.getArticleList().observe(this, new Observer<List<Article>>() {
+        viewModel.getChannel().observe(this, new Observer<Channel>() {
             @Override
-            public void onChanged(List<Article> articles) {
-                if (articles != null) {
-                    mAdapter = new ArticleAdapter(articles, MainActivity.this);
+            public void onChanged(Channel channel) {
+                if (channel != null) {
+                    if (channel.getTitle() != null) {
+                        setTitle(channel.getTitle());
+                    }
+                    mAdapter = new ArticleAdapter(channel.getArticles(), MainActivity.this);
                     mRecyclerView.setAdapter(mAdapter);
                     mAdapter.notifyDataSetChanged();
                     progressBar.setVisibility(View.GONE);

--- a/samplejava/src/main/java/com/prof/rssparser/sample/java/MainViewModel.java
+++ b/samplejava/src/main/java/com/prof/rssparser/sample/java/MainViewModel.java
@@ -17,34 +17,33 @@
 
 package com.prof.rssparser.sample.java;
 
-import com.prof.rssparser.Article;
-import com.prof.rssparser.OnTaskCompleted;
-import com.prof.rssparser.Parser;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Executors;
-
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
+import com.prof.rssparser.Article;
+import com.prof.rssparser.Channel;
+import com.prof.rssparser.OnTaskCompleted;
+import com.prof.rssparser.Parser;
+
+import java.util.ArrayList;
+
 public class MainViewModel extends ViewModel {
 
-    private MutableLiveData<List<Article>> articleListLive = null;
+    private MutableLiveData<Channel> articleListLive = null;
     private String urlString = "https://www.androidauthority.com/feed";
 
     private MutableLiveData<String> snackbar = new MutableLiveData<>();
 
-    public MutableLiveData<List<Article>> getArticleList() {
+    public MutableLiveData<Channel> getChannel() {
         if (articleListLive == null) {
             articleListLive = new MutableLiveData<>();
         }
         return articleListLive;
     }
 
-    private void setArticleList(List<Article> articleList) {
-        this.articleListLive.postValue(articleList);
+    private void setChannel(Channel channel) {
+        this.articleListLive.postValue(channel);
     }
 
     public LiveData<String> getSnackbar() {
@@ -62,14 +61,14 @@ public class MainViewModel extends ViewModel {
 
             //what to do when the parsing is done
             @Override
-            public void onTaskCompleted(List<Article> list) {
-                setArticleList(list);
+            public void onTaskCompleted(Channel channel) {
+                setChannel(channel);
             }
 
             //what to do in case of error
             @Override
             public void onError(Exception e) {
-                setArticleList(new ArrayList<Article>());
+                setChannel(new Channel(null, null, null, new ArrayList<Article>()));
                 e.printStackTrace();
                 snackbar.postValue("An error has occurred. Please try again");
             }

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainActivity.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainActivity.kt
@@ -61,10 +61,13 @@ class MainActivity : AppCompatActivity() {
         recycler_view.itemAnimator = DefaultItemAnimator()
         recycler_view.setHasFixedSize(true)
 
-        viewModel.getArticleList().observe(this, Observer { articles ->
+        viewModel.getArticleList().observe(this, Observer { channel ->
 
-            if (articles != null) {
-                adapter = ArticleAdapter(articles)
+            if (channel != null) {
+                if (channel.title != null) {
+                    title = channel.title
+                }
+                adapter = ArticleAdapter(channel.articles)
                 recycler_view.adapter = adapter
                 adapter.notifyDataSetChanged()
                 progressBar.visibility = View.GONE

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
@@ -20,7 +20,7 @@ package com.prof.rssparser.sample.kotlin
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.prof.rssparser.Article
+import com.prof.rssparser.Channel
 import com.prof.rssparser.Parser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +34,7 @@ class MainViewModel : ViewModel() {
     private val viewModelJob = Job()
     private val coroutineScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
-    private lateinit var articleListLive: MutableLiveData<MutableList<Article>>
+    private lateinit var articleListLive: MutableLiveData<Channel>
 
     private val _snackbar = MutableLiveData<String>()
 
@@ -45,15 +45,15 @@ class MainViewModel : ViewModel() {
         _snackbar.value = null
     }
 
-    fun getArticleList(): MutableLiveData<MutableList<Article>> {
+    fun getArticleList(): MutableLiveData<Channel> {
         if (!::articleListLive.isInitialized) {
             articleListLive = MutableLiveData()
         }
         return articleListLive
     }
 
-    private fun setArticleList(articleList: MutableList<Article>) {
-        articleListLive.postValue(articleList)
+    private fun setChannel(channel: Channel) {
+        articleListLive.postValue(channel)
     }
 
     override fun onCleared() {
@@ -66,11 +66,11 @@ class MainViewModel : ViewModel() {
             try {
                 val parser = Parser()
                 val articleList = parser.getArticles(url)
-                setArticleList(articleList)
+                setChannel(articleList)
             } catch (e: Exception) {
                 e.printStackTrace()
                 _snackbar.value = "An error has occurred. Please retry"
-                setArticleList(mutableListOf())
+                setChannel(Channel(null, null, null, mutableListOf()))
             }
         }
     }

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
@@ -65,7 +65,7 @@ class MainViewModel : ViewModel() {
         coroutineScope.launch(Dispatchers.Main) {
             try {
                 val parser = Parser()
-                val articleList = parser.getArticles(url)
+                val articleList = parser.getChannel(url)
                 setChannel(articleList)
             } catch (e: Exception) {
                 e.printStackTrace()


### PR DESCRIPTION
Hello again.
First of all, nice work on the library.
Encouraged by the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) I decided to make small contribution to the open source community. This is the PR addressing issue #32.

Instead of returning a list of articles, the parser now returns `Channel` object which contains a list of `Article` objects and some additional info about the channel. 

This way, parsing new data about the channel will be easyer in the future since you won't have to make new model again, but instead just fill the `Channel` with new data.

Cheers! :)