### PR TITLE
Parse Raw Data without Caching and Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The library provides a caching layer to avoid wasting data with very long feeds.
 
 ### RSS Parsing from string
 
-COMING SOON
+The library provides a way of simply parsing raw data into POJOs.
 
 ## Installation
 
@@ -117,6 +117,23 @@ For flushing the cache:
 
 ```Kotlin
 parser.flushCache(url)
+```
+
+For simply parsing raw data:
+
+```kotlin
+// parser without any network or caching configuration
+val parser = Parser.Builder().build()
+
+viewModelScope.launch {
+    try {
+        val channel = parser.parse(raw)
+        // Do something with your data
+    } catch (e: Exception) {
+        e.printStackTrace()
+        // Handle the exception
+    }
+}
 ```
 
 You can give a look to the full Kotlin sample by clicking [here](https://github.com/prof18/RSS-Parser/tree/master/samplekotlin)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ parser.flushCache(url)
 ```
 
 For simply parsing raw data:
+- A `suspend` function `Parser#parser(rawRssFeed)` which returns the channel.  
+- A java compatible function `Parser.parser(rawRssFeed, OnTaskCompleted)` which calls the listener once done.
 
 ```kotlin
 // parser without any network or caching configuration

--- a/rssparser/src/main/java/com/prof/rssparser/Parser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/Parser.kt
@@ -19,7 +19,9 @@ package com.prof.rssparser
 
 import android.content.Context
 import android.util.Log
+import androidx.annotation.WorkerThread
 import com.prof.rssparser.caching.CacheManager
+import com.prof.rssparser.core.CoreXMLParser
 import com.prof.rssparser.engine.XMLFetcher
 import com.prof.rssparser.engine.XMLParser
 import com.prof.rssparser.enginecoroutine.CoroutineEngine
@@ -194,6 +196,26 @@ class Parser private constructor(private var okHttpClient: OkHttpClient? = null,
      */
     @Throws(Exception::class)
     suspend fun parse(rawRssFeed: String): Channel = CoroutineEngine.parseXML(rawRssFeed)
+
+    /**
+     * Parses the [rawRssFeed] into a [Channel] and notifies the [listener].
+     *
+     * If the operation is successful, then [OnTaskCompleted.onTaskCompleted] is called with
+     * the parsed channel. Otherwise, [OnTaskCompleted.onError]  is called.
+     *
+     * @exception Exception if something goes wrong during the parsing of the RSS feed.
+     * @param rawRssFeed The Raw data of the Rss Feed.
+     * @param listener Completion listener
+     */
+    @Throws(Exception::class)
+    @WorkerThread
+    fun parse(rawRssFeed: String, listener: OnTaskCompleted) {
+        try {
+            listener.onTaskCompleted(CoreXMLParser.parseXML(rawRssFeed))
+        } catch (exception: Exception) {
+            listener.onError(exception)
+        }
+    }
 
     /**
      *

--- a/rssparser/src/main/java/com/prof/rssparser/caching/CacheConstants.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/caching/CacheConstants.kt
@@ -1,6 +1,6 @@
 package com.prof.rssparser.caching
 
-object CacheConstants {
+internal object CacheConstants {
     const val CACHED_FEEDS_TABLE_NAME = "feeds"
     const val CACHED_FEEDS_URL_HASH = "url_hash"
 

--- a/rssparser/src/main/java/com/prof/rssparser/caching/CacheDatabase.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/caching/CacheDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 
 @Database(entities = [CachedFeed::class], version = 1)
-abstract class CacheDatabase: RoomDatabase() {
+internal abstract class CacheDatabase: RoomDatabase() {
     abstract fun cachedProjectsDao(): CachedFeedDao
     
     companion object {

--- a/rssparser/src/main/java/com/prof/rssparser/caching/CacheManager.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/caching/CacheManager.kt
@@ -19,7 +19,7 @@ import java.io.ObjectOutputStream
  *  the test, to provide a TestCoroutineDispatcher
  *
  */
-class CacheManager(internal val database: CacheDatabase, // internal just for close db during testing
+internal class CacheManager(internal val database: CacheDatabase, // internal just for close db during testing
                    private val cacheDurationMillis: Long,
                    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {

--- a/rssparser/src/main/java/com/prof/rssparser/caching/CachedFeed.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/caching/CachedFeed.kt
@@ -5,7 +5,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 @Entity(tableName = CacheConstants.CACHED_FEEDS_TABLE_NAME)
-class CachedFeed(
+internal class CachedFeed(
         @PrimaryKey
         @ColumnInfo(name = "url_hash")
         var urlHash: Int,

--- a/rssparser/src/main/java/com/prof/rssparser/caching/CachedFeedDao.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/caching/CachedFeedDao.kt
@@ -6,7 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
 @Dao
-abstract class CachedFeedDao {
+internal abstract class CachedFeedDao {
     @Query(CacheConstants.QUERY_GET_CACHED_PROJECT)
     abstract suspend fun getCachedProject(urlHash: Int): CachedFeed?
 

--- a/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLFetcher.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLFetcher.kt
@@ -5,7 +5,7 @@ import okhttp3.Request
 import java.lang.Exception
 import java.nio.charset.Charset
 
-object CoreXMLFetcher {
+internal object CoreXMLFetcher {
     @Throws(Exception::class)
     fun fetchXML(url: String, okHttpClient: OkHttpClient? = null, charset: Charset): String {
         var client = okHttpClient

--- a/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
@@ -30,7 +30,7 @@ import java.io.InputStreamReader
 import java.io.Reader
 import java.util.regex.Pattern
 
-object CoreXMLParser {
+internal object CoreXMLParser {
 
     @Throws(XmlPullParserException::class, IOException::class)
     fun parseXML(xml: String): Channel {

--- a/rssparser/src/main/java/com/prof/rssparser/engine/XMLFetcher.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/engine/XMLFetcher.kt
@@ -22,7 +22,7 @@ import okhttp3.OkHttpClient
 import java.nio.charset.Charset
 import java.util.concurrent.Callable
 
-class XMLFetcher(private val url: String, private val okHttpClient: OkHttpClient?, private val charset: Charset) : Callable<String> {
+internal class XMLFetcher(private val url: String, private val okHttpClient: OkHttpClient?, private val charset: Charset) : Callable<String> {
 
     @Throws(Exception::class)
     override fun call(): String {

--- a/rssparser/src/main/java/com/prof/rssparser/engine/XMLParser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/engine/XMLParser.kt
@@ -21,7 +21,7 @@ import com.prof.rssparser.Channel
 import com.prof.rssparser.core.CoreXMLParser
 import java.util.concurrent.Callable
 
-class XMLParser(var xml: String) : Callable<Channel> {
+internal class XMLParser(var xml: String) : Callable<Channel> {
 
     @Throws(Exception::class)
     override fun call(): Channel {

--- a/rssparser/src/main/java/com/prof/rssparser/enginecoroutine/CoroutineEngine.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/enginecoroutine/CoroutineEngine.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import java.nio.charset.Charset
 
-object CoroutineEngine {
+internal object CoroutineEngine {
 
     @Throws(Exception::class)
     suspend fun fetchXML(url: String, okHttpClient: OkHttpClient?, charset: Charset): String = withContext(Dispatchers.IO) {

--- a/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
@@ -17,7 +17,7 @@
 
 package com.prof.rssparser.utils
 
-object RSSKeywords {
+internal object RSSKeywords {
 
     // channel
     const val RSS_CHANNEL = "channel"

--- a/samplekotlin/build.gradle
+++ b/samplekotlin/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.lifecycle}"
     implementation "androidx.activity:activity-ktx:${versions.activityAndroidx}"
+    implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 }

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainActivity.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainActivity.kt
@@ -37,8 +37,12 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.prof.rssparser.Parser
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.content_main.*
+import com.prof.rssparser.sample.kotlin.util.AlertDialogHelper
+import kotlinx.android.synthetic.main.activity_main.toolbar
+import kotlinx.android.synthetic.main.content_main.progressBar
+import kotlinx.android.synthetic.main.content_main.recycler_view
+import kotlinx.android.synthetic.main.content_main.root_layout
+import kotlinx.android.synthetic.main.content_main.swipe_layout
 
 class MainActivity : AppCompatActivity() {
 
@@ -54,11 +58,11 @@ class MainActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
 
         parser = Parser.Builder()
-                .context(this)
-                // If you want to provide a custom charset (the default is utf-8):
-                // .charset(Charset.forName("ISO-8859-7"))
-                .cacheExpirationMillis(24L * 60L * 60L * 100L) // one day
-                .build()
+            .context(this)
+            // If you want to provide a custom charset (the default is utf-8):
+            // .charset(Charset.forName("ISO-8859-7"))
+            .cacheExpirationMillis(24L * 60L * 60L * 100L) // one day
+            .build()
 
         recycler_view.layoutManager = LinearLayoutManager(this)
         recycler_view.itemAnimator = DefaultItemAnimator()
@@ -97,10 +101,10 @@ class MainActivity : AppCompatActivity() {
         if (!isOnline()) {
             val builder = AlertDialog.Builder(this)
             builder.setMessage(R.string.alert_message)
-                    .setTitle(R.string.alert_title)
-                    .setCancelable(false)
-                    .setPositiveButton(R.string.alert_positive
-                    ) { dialog, id -> finish() }
+                .setTitle(R.string.alert_title)
+                .setCancelable(false)
+                .setPositiveButton(R.string.alert_positive
+                ) { dialog, id -> finish() }
 
             val alert = builder.create()
             alert.show()
@@ -119,16 +123,24 @@ class MainActivity : AppCompatActivity() {
         val id = item.itemId
 
         if (id == R.id.action_settings) {
-            val alertDialog = androidx.appcompat.app.AlertDialog.Builder(this@MainActivity).create()
+            val alertDialog = AlertDialog.Builder(this@MainActivity).create()
             alertDialog.setTitle(R.string.app_name)
             alertDialog.setMessage(Html.fromHtml(this@MainActivity.getString(R.string.info_text) +
-                    " <a href='http://github.com/prof18/RSS-Parser'>GitHub.</a>" +
-                    this@MainActivity.getString(R.string.author)))
-            alertDialog.setButton(androidx.appcompat.app.AlertDialog.BUTTON_NEUTRAL, "OK"
+                " <a href='http://github.com/prof18/RSS-Parser'>GitHub.</a>" +
+                this@MainActivity.getString(R.string.author)))
+            alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "OK"
             ) { dialog, which -> dialog.dismiss() }
             alertDialog.show()
 
             (alertDialog.findViewById<View>(android.R.id.message) as TextView).movementMethod = LinkMovementMethod.getInstance()
+        } else if (id == R.id.action_raw_parser) {
+            AlertDialogHelper(
+                title = R.string.alert_raw_parser_title,
+                positiveButton = R.string.alert_raw_parser_positive,
+                negativeButton = R.string.alert_raw_parser_negative
+            ).buildInputDialog(this) { url ->
+                viewModel.fetchForUrlAndParseRawRata(url)
+            }.show()
         }
 
         return super.onOptionsItemSelected(item)

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
@@ -71,9 +71,9 @@ class MainViewModel : ViewModel() {
                 .build()
             val result = okHttpClient.newCall(request).execute()
             val raw = runCatching { result.body()?.string() }.getOrNull()
-            if(raw == null){
+            if (raw == null) {
                 _snackbar.postValue("Something went wrong!")
-            } else{
+            } else {
                 val channel = parser.parse(raw)
                 _rssChannel.postValue(channel)
             }

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/MainViewModel.kt
@@ -23,7 +23,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prof.rssparser.Channel
 import com.prof.rssparser.Parser
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
 
 class MainViewModel : ViewModel() {
 
@@ -38,6 +41,10 @@ class MainViewModel : ViewModel() {
     val rssChannel: LiveData<Channel>
         get() = _rssChannel
 
+    private val okHttpClient by lazy {
+        OkHttpClient()
+    }
+
     fun onSnackbarShowed() {
         _snackbar.value = null
     }
@@ -51,6 +58,24 @@ class MainViewModel : ViewModel() {
                 e.printStackTrace()
                 _snackbar.value = "An error has occurred. Please retry"
                 _rssChannel.postValue(Channel(null, null, null, null, null, null, mutableListOf()))
+            }
+        }
+    }
+
+    fun fetchForUrlAndParseRawRata(url: String) {
+        val parser = Parser.Builder().build()
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url(url)
+                .build()
+            val result = okHttpClient.newCall(request).execute()
+            val raw = runCatching { result.body()?.string() }.getOrNull()
+            if(raw == null){
+                _snackbar.postValue("Something went wrong!")
+            } else{
+                val channel = parser.parse(raw)
+                _rssChannel.postValue(channel)
             }
         }
     }

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/util/AlertDialogHelper.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/util/AlertDialogHelper.kt
@@ -1,0 +1,4 @@
+package com.prof.rssparser.sample.kotlin.util
+
+class InputAlertDialog {
+}

--- a/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/util/AlertDialogHelper.kt
+++ b/samplekotlin/src/main/java/com/prof/rssparser/sample/kotlin/util/AlertDialogHelper.kt
@@ -1,4 +1,28 @@
 package com.prof.rssparser.sample.kotlin.util
 
-class InputAlertDialog {
+import android.app.AlertDialog
+import android.content.Context
+import android.widget.EditText
+import androidx.annotation.StringRes
+
+class AlertDialogHelper(
+    @StringRes private val title: Int,
+    @StringRes private val positiveButton: Int,
+    @StringRes private val negativeButton: Int
+) {
+    fun buildInputDialog(
+        context: Context,
+        onPositiveAction: (url: String) -> Unit
+    ): AlertDialog {
+        val editText = EditText(context)
+        return AlertDialog.Builder(context)
+            .setTitle(title)
+            .setView(editText)
+            .setNegativeButton(negativeButton) { dialog, _ ->
+                dialog.dismiss()
+            }.setPositiveButton(positiveButton) { dialog, _ ->
+                onPositiveAction(editText.text?.toString().orEmpty())
+                dialog.dismiss()
+            }.create()
+    }
 }

--- a/samplekotlin/src/main/res/menu/menu_main.xml
+++ b/samplekotlin/src/main/res/menu/menu_main.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.prof.rssparser.example.MainActivity">
     <item
+        android:id="@+id/action_raw_parser"
+        android:title="@string/action_raw_parser"
+        android:orderInCategory="200"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
         android:title="@string/action_about"

--- a/samplekotlin/src/main/res/values/strings.xml
+++ b/samplekotlin/src/main/res/values/strings.xml
@@ -32,4 +32,8 @@
      <string name="info_text">This is a simple app that shows the use of RSS Parse library.
          &lt;br /&gt;&lt;br /&gt;You can find the source code on </string>
     <string name="author">&lt;br /&gt;&lt;br /&gt;Written by Marco Gomiero</string>
+    <string name="action_raw_parser">Parse raw data from URL</string>
+    <string name="alert_raw_parser_title">Add an RSS feed url</string>
+    <string name="alert_raw_parser_positive">Ok</string>
+    <string name="alert_raw_parser_negative">Cancel</string>
 </resources>


### PR DESCRIPTION
- Add a public API for parsing raw data. This allows users of the library to implement their own networking layer and caching. The change is compatible for both Kotlin and Java. https://github.com/prof18/RSS-Parser/commit/d269487b1b39b97f65725655156790af4bb9340f https://github.com/prof18/RSS-Parser/commit/82106f67e12541599e0fc02167b6633296b3393a
- Mark internal API with `internal` https://github.com/prof18/RSS-Parser/commit/0e95678fa958b989d5472a04d4b28f6466393dfb
- Updated README.md to include the new API 
- Updated `samplekotlin` to include the parsing of raw data. Please see attached GIF for a demo. https://github.com/prof18/RSS-Parser/commit/3399a774ff0b2498df972784129afccee3f26c2f

![samplekotlin](https://user-images.githubusercontent.com/25663514/87244251-d8ecdf80-c433-11ea-800b-4ae28ec7a871.gif)

