### PR TITLE
<itunes:image> tag added

### DIFF
--- a/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/core/CoreXMLParser.kt
@@ -132,6 +132,11 @@ internal object CoreXMLParser {
                         channelImage?.url = xmlPullParser.nextText().trim()
                     }
 
+                } else if (xmlPullParser.name.equals(RSSKeywords.RSS_ITEM_ITUNES_IMAGE, ignoreCase = true)) {
+                    if (insideItem) {
+                        currentArticle.image = xmlPullParser.getAttributeValue(null, RSSKeywords.RSS_ITEM_HREF)
+                    }
+
                 } else if (xmlPullParser.name.equals(RSSKeywords.RSS_ITEM_ENCLOSURE, ignoreCase = true)) {
                     if (insideItem) {
                         val type = xmlPullParser.getAttributeValue(null, RSSKeywords.RSS_ITEM_TYPE)

--- a/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
+++ b/rssparser/src/main/java/com/prof/rssparser/utils/RSSKeywords.kt
@@ -42,4 +42,6 @@ internal object RSSKeywords {
     const val RSS_ITEM_TYPE = "type"
     const val RSS_ITEM_GUID = "guid"
     const val RSS_ITEM_SOURCE = "source"
+    const val RSS_ITEM_ITUNES_IMAGE = "itunes:image"
+    const val RSS_ITEM_HREF = "href"
 }


### PR DESCRIPTION
Right now podcast rss feed is parsed without specific episode images. All articles in podcast chanel have empty image.
Podcast rss feed always has item with episode image tag (**<itunes:image>**). Soundcloud feed example:

>    
      <guid isPermaLink="false">tag:soundcloud,2010:tracks/677542482</guid>   
      <title>Dog</title>    
      <pubDate>Sat, 07 Sep 2019 07:02:49 +0000</pubDate>
      <link>https://soundcloud.com/user-50021506-573880122/sobaka</link>
      <itunes:duration>00:01:50</itunes:duration>
      <itunes:author>DomPerignon</itunes:author>
      <itunes:explicit>no</itunes:explicit>
      <itunes:summary>Dog by DomPerignon</itunes:summary>
      <itunes:subtitle>Dog by DomPerignon</itunes:subtitle>
      <description>Dog by DomPerignon</description>
      <enclosure type="audio/mpeg" url="https://feeds.soundcloud.com/stream/677542482-user-50021506-573880122-sobaka.mp3" length="2647561"/>
      <itunes:image href="https://i1.sndcdn.com/artworks-000594144414-1bzec9-t3000x3000.jpg"/>
    </item>

So , I have added if clause for RSS_ITEM_ITUNES_IMAGE. We will assign image to currentArticle.image.