### PR TITLE
README: Mention ReLabs among apps using RSS-Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ If you are using RSS Parser in your app and would like to be listed here, please
     <summary>List of Apps using RSS Parser</summary>
 
     * [FeedFlow](https://www.feedflow.com)
+    * [ReLabs](https://github.com/theimpulson/ReLabs)
 
 </details>
 


### PR DESCRIPTION
## Summary

This PR mentions [ReLabs](https://xdaforums.com/t/app-5-0-relabs-unofficial-xda-client.4623759/) which is an unofficial Client for XDA (XDA Developers) as one of the apps using RSS-Parser library.