### PR TITLE
Fix image empty tag parsing on Android

### DIFF
--- a/rssparser/src/androidMain/kotlin/com/prof18/rssparser/internal/rss/RssParser.kt
+++ b/rssparser/src/androidMain/kotlin/com/prof18/rssparser/internal/rss/RssParser.kt
@@ -265,9 +265,9 @@ internal fun CoroutineScope.extractRSSContent(
                     insideChannel && !insideItem -> insideChannelImage = true
                     insideItem -> {
                         xmlPullParser.next()
-                        val text = xmlPullParser.text.trim()
+                        val text = xmlPullParser.text?.trim()
                         // Get the image text if it's not contained in another tag
-                        if (text.isNotEmpty()) {
+                        if (!text.isNullOrEmpty()) {
                             channelFactory.articleBuilder.image(text)
                         } else {
                             xmlPullParser.next()

--- a/rssparser/src/commonTest/kotlin/com/prof18/rssparser/rss/XmlParserImageEmptyTag.kt
+++ b/rssparser/src/commonTest/kotlin/com/prof18/rssparser/rss/XmlParserImageEmptyTag.kt
@@ -1,0 +1,47 @@
+/*
+*   Copyright 2019 Marco Gomiero
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*/
+
+package com.prof18.rssparser.rss
+
+import com.prof18.rssparser.BaseXmlParserTest
+import com.prof18.rssparser.model.RssImage
+
+class XmlParserImageEmptyTag : BaseXmlParserTest(
+    feedPath = "feed-test-image-empty-tag.xml",
+    channelTitle = "Hacker Noon",
+    channelLink = "https://hackernoon.com",
+    channelDescription = "How hackers start their afternoons.",
+    channelImage = null,
+    channelLastBuildDate = "Sun, 29 Oct 2023 10:00:20 GMT",
+    channelUpdatePeriod = null,
+    channelItunesData = null,
+    articleGuid = "https://hackernoon.com/miscellaneous-directions?source=rss",
+    articleTitle = "MISCELLANEOUS DIRECTIONS.",
+    articleAuthor = "Catharine Esther Beecher",
+    articleLink = "https://hackernoon.com/miscellaneous-directions?source=rss",
+    articlePubDate = "Sun, 29 Oct 2023 09:00:01 GMT",
+    articleDescription = "Every woman should know how to direct in regard to the proper care of domestic animals.",
+    articleContent = null,
+    articleImage = "https://hackernoon.com/https://cdn.hackernoon.com/images/3cu1ROR1ocaekNNTdramI0w9qNj2-xl93swo.jpeg",
+    articleAudio = null,
+    articleVideo = null,
+    articleSourceName = null,
+    articleSourceUrl = null,
+    articleCategories = listOf("domestic-manuals"),
+    articleCommentsUrl = null,
+    articleItunesData = null,
+)

--- a/rssparser/src/commonTest/resources/feed-test-image-empty-tag.xml
+++ b/rssparser/src/commonTest/resources/feed-test-image-empty-tag.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:cc="http://web.resource.org/cc/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <channel>
+        <title><![CDATA[Hacker Noon]]></title>
+        <description><![CDATA[How hackers start their afternoons.]]></description>
+        <link>https://hackernoon.com</link>
+        <image />
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Sun, 29 Oct 2023 10:00:20 GMT</lastBuildDate>
+        <atom:link href="https://hackernoon.com/feed" rel="self" type="application/rss+xml" />
+        <pubDate>Sun, 29 Oct 2023 10:00:17 GMT</pubDate>
+        <snf:logo>https://hackernoon.com/hn-logo.png</snf:logo>
+        <item>
+            <title><![CDATA[MISCELLANEOUS DIRECTIONS.]]></title>
+            <description><![CDATA[Every woman should know how to direct in regard to the proper care of domestic animals.]]></description>
+            <link>https://hackernoon.com/miscellaneous-directions?source=rss</link>
+            <guid isPermaLink="true">https://hackernoon.com/miscellaneous-directions?source=rss</guid>
+            <category><![CDATA[domestic-manuals]]></category>
+            <dc:creator><![CDATA[Catharine Esther Beecher ]]></dc:creator>
+            <pubDate>Sun, 29 Oct 2023 09:00:01 GMT</pubDate>
+            <image />
+            <media:thumbnail
+                url="https://hackernoon.com/https://cdn.hackernoon.com/images/3cu1ROR1ocaekNNTdramI0w9qNj2-xl93swo.jpeg" />
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
Hey, first of all thanks for the great library. 

I've come across parsing rss feed from https://hackernoon.com/feed and noticed that they have an empty `image` tag followed by `media:thumbnail` with the actual image.
The Android XML parser is crashing with NPE at that line trying to trim an null string
```
val text = xmlPullParser.text.trim()
```

I this PR I'am proposing an easy fix for that bug.