### PR TITLE
Add Capy Reader to list of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ If you are using RSS Parser in your app and would like to be listed here, please
 
 * [FeedFlow](https://www.feedflow.dev)
 * [ReLabs](https://github.com/theimpulson/ReLabs)
-    
+* [CapyReader](https://capyreader.com/)
+
 </details>
 


### PR DESCRIPTION
I couldn't have built my own RSS app without this library. The full implementation is [on GitHub](https://github.com/jocmp/capyreader), specifically in the "feedfinder" module.