### PR TITLE
Bump Android compile SDK to 36

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
         with:
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
         with:
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
         with:
@@ -111,7 +111,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
         with:
@@ -138,7 +138,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
         with:
@@ -165,7 +165,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Xcode version
         run: |
@@ -204,7 +204,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Xcode version
         run: |
@@ -243,7 +243,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Xcode version
         run: |
@@ -283,7 +283,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - name: Xcode version
         run: |
@@ -322,7 +322,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
         with:

--- a/.github/workflows/publish-library.yaml
+++ b/.github/workflows/publish-library.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v3
         with:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-gradle-plugin = "9.0.0"
-android-compile-sdk = "34"
+android-compile-sdk = "36"
 android-min-sdk = "21"
 android-target-sdk = "34"
 kotlin = "2.4.0"


### PR DESCRIPTION
## Summary
- Bump the shared Android compile SDK version from 34 to 36.

## Local verification
- ./gradlew -q --console=plain :rssparser:testAndroidHostTest :rssparser:jvmTest :rssparser:apiCheck :samples:multiplatform:androidApp:assembleRelease :samples:android:assembleRelease :samples:java:assembleRelease
- ./gradlew -q --console=plain :samples:multiplatform:desktopApp:packageDistributionForCurrentOS :samples:multiplatform:webApp:wasmJsBrowserDistribution
- ./gradlew -q --console=plain :rssparser:check -x :rssparser:tvosSimulatorArm64Test -x :rssparser:tvosX64Test -x :rssparser:watchosSimulatorArm64Test -x :rssparser:watchosX64Test
- ./gradlew -q --console=plain check -x :rssparser:tvosSimulatorArm64Test -x :rssparser:tvosX64Test -x :rssparser:watchosSimulatorArm64Test -x :rssparser:watchosX64Test

Note: full local :rssparser:check without exclusions is blocked on this machine because no tvOS/watchOS simulator runtimes are installed locally; CI runs those Apple lanes separately.